### PR TITLE
Refactor/interep groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ Deploy the Interep contract with one Semaphore verifier:
 yarn deploy:interep --verifiers '[[20, "0x5FbDB2315678afecb367f032d93F642f64180aa3"]]'
 ```
 
-If you want to deploy contracts in a specific network you can set up the `DEFAULT_NETWORK` variable in your `.env` file with the name of one of our supported networks (hardhat, localhost, ropsten, kovan, arbitrum). Or you can specify it as option:
+If you want to deploy contracts in a specific network you can set up the `DEFAULT_NETWORK` variable in your `.env` file with the name of one of our supported networks (hardhat, localhost, goerli, kovan, arbitrum). Or you can specify it as option:
 
 ```bash
 yarn deploy:interep --verifiers '[[20, "0x06bcD633988c1CE7Bd134DbE2C12119b6f3E4bD1"]]' --network kovan
 yarn deploy:interep --verifiers '[[20, "0x5FbDB2315678afecb367f032d93F642f64180aa3"]]' --network localhost
 ```
 
-If you want to deploy the contracts on Ropsten, Kovan or Arbitrum remember to provide a valid private key and an Infura API in your `.env` file.
+If you want to deploy the contracts on Goerli, Kovan or Arbitrum remember to provide a valid private key and an Infura API in your `.env` file.
 
 ### Preparing a local network
 

--- a/contracts/IInterep.sol
+++ b/contracts/IInterep.sol
@@ -1,10 +1,10 @@
-//SPDX-License-Identifier: GPL-3.0
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 /// @title Interep interface.
 /// @dev Interface of a Interep contract.
 interface IInterep {
-    struct OffchainGroup {
+    struct Group {
         bytes32 provider;
         bytes32 name;
         uint256 root;
@@ -16,13 +16,13 @@ interface IInterep {
     /// @param signal: Semaphore signal.
     event ProofVerified(uint256 indexed groupId, bytes32 signal);
 
-    /// @dev Emitted when an offchain group is updated.
+    /// @dev Emitted when an Interep group is updated.
     /// @param groupId: Id of the group.
     /// @param provider: Provider of the group.
     /// @param name: Name of the group.
     /// @param root: Root hash of the tree.
     /// @param depth: Depth of the tree.
-    event OffchainGroupUpdated(
+    event GroupUpdated(
         uint256 groupId,
         bytes32 indexed provider,
         bytes32 indexed name,
@@ -30,17 +30,11 @@ interface IInterep {
         uint8 indexed depth
     );
 
-    /// @dev Emitted when an admin is assigned to an onchain group.
-    /// @param groupId: Id of the group.
-    /// @param oldAdmin: Old admin of the group.
-    /// @param newAdmin: New admin of the group.
-    event GroupAdminUpdated(uint256 indexed groupId, address indexed oldAdmin, address indexed newAdmin);
+    /// @dev Updates the Interep groups.
+    /// @param groups: List of Interep groups.
+    function updateGroups(Group[] calldata groups) external;
 
-    /// @dev Updates a list of offchain groups. It is useful to ensure the integrity of the Interep offchain trees.
-    /// @param groups: List of the offchain groups (with tree depth and root).
-    function updateOffchainGroups(OffchainGroup[] calldata groups) external;
-
-    /// @dev Saves the nullifier hash to avoid double signaling and exit an event
+    /// @dev Saves the nullifier hash to avoid double signaling and emits an event
     /// if the zero-knowledge proof is valid.
     /// @param groupId: Id of the group.
     /// @param signal: Semaphore signal.
@@ -55,46 +49,13 @@ interface IInterep {
         uint256[8] calldata proof
     ) external;
 
-    /// @dev Creates a new onchain group. Only the admin will be able to add or remove members.
-    /// @param groupId: Id of the group.
-    /// @param depth: Depth of the tree.
-    /// @param admin: Admin of the group.
-    function createGroup(
-        uint256 groupId,
-        uint8 depth,
-        address admin
-    ) external;
-
-    /// @dev Updates the admin of an onchain group.
-    /// @param groupId: Id of the group.
-    /// @param newAdmin: New admin of the group.
-    function updateGroupAdmin(uint256 groupId, address newAdmin) external;
-
-    /// @dev Adds a new member to an existing onchain group.
-    /// @param groupId: Id of the group.
-    /// @param identityCommitment: New identity commitment.
-    function addMember(uint256 groupId, uint256 identityCommitment) external;
-
-    /// @dev Removes a member from an existing onchain group. A proof of membership is
-    /// needed to check if the node to be removed is part of the onchain tree.
-    /// @param groupId: Id of the group.
-    /// @param identityCommitment: Identity commitment to be deleted.
-    /// @param proofSiblings: Array of the sibling nodes of the proof of membership.
-    /// @param proofPathIndices: Path of the proof of membership.
-    function removeMember(
-        uint256 groupId,
-        uint256 identityCommitment,
-        uint256[] calldata proofSiblings,
-        uint8[] calldata proofPathIndices
-    ) external;
-
-    /// @dev Returns the root hash of an offchain group.
+    /// @dev Returns the root hash of an Interep group.
     /// @param groupId: Id of the group.
     /// @return Root hash of the group.
-    function getOffchainRoot(uint256 groupId) external view returns (uint256);
+    function getRoot(uint256 groupId) external view returns (uint256);
 
-    /// @dev Returns the tree depth of an offchain group.
+    /// @dev Returns the tree depth of an Interep group.
     /// @param groupId: Id of the group.
     /// @return Tree depth of the group.
-    function getOffchainDepth(uint256 groupId) external view returns (uint8);
+    function getDepth(uint256 groupId) external view returns (uint8);
 }

--- a/contracts/Interep.sol
+++ b/contracts/Interep.sol
@@ -5,33 +5,20 @@ import "./IInterep.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@appliedzkp/semaphore-contracts/interfaces/IVerifier.sol";
 import "@appliedzkp/semaphore-contracts/base/SemaphoreCore.sol";
-import "@appliedzkp/semaphore-contracts/base/SemaphoreGroups.sol";
+import "@appliedzkp/semaphore-contracts/base/SemaphoreConstants.sol";
 
 /// @title Interep
-/// @dev Interep is a collection of groups (onchain and offchain) where members can prove
-/// their membership without revealing their identity. DApps can use this contract to verify
-/// if a Semaphore proof is valid and then use its signal.
+/// @dev Interep is a collection of reputation Semaphore groups in which members
+/// can prove their Web2 reputation (or their membership in a group) without revealing their identity.
 /// Each Interep group is actually a Merkle tree, whose leaves represent the members of the group.
-/// `depth` and `root` therefore refer to the tree. Interep groups can be divided into two types:
-/// onchain groups managed entirely with the `SemaphoreGroups` contracts, and offchain groups managed
-/// by Interep's servers. The tree roots used in offchain groups are updated at regular intervals
-/// by Interep with the `addOffchainGroups` function.
-contract Interep is IInterep, Ownable, SemaphoreCore, SemaphoreGroups {
+/// Interep groups are saved off-chain but the Merkle tree roots of those groups are saved on-chain
+/// at regular intervals, so that users can verify their Semaphore ZK proof on-chain with this contract.
+contract Interep is IInterep, Ownable, SemaphoreCore {
     /// @dev Gets a tree depth and returns its verifier address.
     mapping(uint8 => IVerifier) public verifiers;
 
-    /// @dev Gets a group id and returns the offchain group (tree root and depth).
-    mapping(uint256 => OffchainGroup) public offchainGroups;
-
-    /// @dev Gets a group id and returns the group admin address.
-    mapping(uint256 => address) public groupAdmins;
-
-    /// @dev Checks if the group admin is the transaction sender.
-    /// @param groupId: Id of the group.
-    modifier onlyGroupAdmin(uint256 groupId) {
-        require(groupAdmins[groupId] == _msgSender(), "Interep: caller is not the group admin");
-        _;
-    }
+    /// @dev Gets a group id and returns the group data.
+    mapping(uint256 => Group) public groups;
 
     /// @dev Checks if there is a verifier for the given tree depth.
     /// @param depth: Depth of the tree.
@@ -40,11 +27,8 @@ contract Interep is IInterep, Ownable, SemaphoreCore, SemaphoreGroups {
         _;
     }
 
-    /// @dev Since there can be multiple verifier contracts (each associated with a certain tree depth),
-    /// it is necessary to pass the addresses of the previously deployed verifier contracts with the associated
-    /// tree depth. Depending on the depth chosen when creating the poll, a certain verifier will be
-    /// used to verify that the proof is correct.
-    /// @param depths: Three depths used in verifiers.
+    /// @dev Initializes the Semaphore verifiers used to verify the user's ZK proofs.
+    /// @param depths: Three depths associated with the verifiers.
     /// @param verifierAddresses: Verifier addresses.
     constructor(uint8[] memory depths, address[] memory verifierAddresses) {
         require(depths.length == verifierAddresses.length, "Interep: parameters lists does not have the same length");
@@ -65,89 +49,43 @@ contract Interep is IInterep, Ownable, SemaphoreCore, SemaphoreGroups {
         uint256 root = getRoot(groupId);
         uint8 depth = getDepth(groupId);
 
-        if (root == 0) {
-            root = getOffchainRoot(groupId);
-            depth = getOffchainDepth(groupId);
-        }
-
         require(depth != 0, "Interep: the group does not exist");
 
         IVerifier verifier = verifiers[depth];
 
         _verifyProof(signal, root, nullifierHash, externalNullifier, proof, verifier);
 
-        // Prevent double-signaling (nullifierHash = hash(pollId + identityNullifier)).
         _saveNullifierHash(nullifierHash);
 
         emit ProofVerified(groupId, signal);
     }
 
-    /// @dev See {IInterep-updateOffchainGroups}.
-    function updateOffchainGroups(OffchainGroup[] calldata groups) external override onlyOwner {
-        for (uint8 i = 0; i < groups.length; i++) {
-            uint256 groupId = uint256(keccak256(abi.encodePacked(groups[i].provider, groups[i].name))) %
+    /// @dev See {IInterep-updateGroups}.
+    function updateGroups(Group[] calldata offchainGroups) external override onlyOwner {
+        for (uint8 i = 0; i < offchainGroups.length; i++) {
+            uint256 groupId = uint256(keccak256(abi.encodePacked(offchainGroups[i].provider, offchainGroups[i].name))) %
                 SNARK_SCALAR_FIELD;
 
-            _updateOffchainGroup(groupId, groups[i]);
+            _updateGroup(groupId, offchainGroups[i]);
         }
     }
 
-    /// @dev See {IInterep-createGroup}.
-    function createGroup(
-        uint256 groupId,
-        uint8 depth,
-        address admin
-    ) external override onlySupportedDepth(depth) {
-        _createGroup(groupId, depth, 0);
-
-        groupAdmins[groupId] = admin;
-
-        emit GroupAdminUpdated(groupId, address(0), admin);
+    /// @dev See {IInterep-getRoot}.
+    function getRoot(uint256 groupId) public view override returns (uint256) {
+        return groups[groupId].root;
     }
 
-    /// @dev See {IInterep-updateGroupAdmin}.
-    function updateGroupAdmin(uint256 groupId, address newAdmin) external override onlyGroupAdmin(groupId) {
-        groupAdmins[groupId] = newAdmin;
-
-        emit GroupAdminUpdated(groupId, _msgSender(), newAdmin);
+    /// @dev See {IInterep-getDepth}.
+    function getDepth(uint256 groupId) public view override returns (uint8) {
+        return groups[groupId].depth;
     }
 
-    /// @dev See {IInterep-addMember}.
-    function addMember(uint256 groupId, uint256 identityCommitment) external override onlyGroupAdmin(groupId) {
-        _addMember(groupId, identityCommitment);
-    }
-
-    /// @dev See {IInterep-removeMember}.
-    function removeMember(
-        uint256 groupId,
-        uint256 identityCommitment,
-        uint256[] calldata proofSiblings,
-        uint8[] calldata proofPathIndices
-    ) external override onlyGroupAdmin(groupId) {
-        _removeMember(groupId, identityCommitment, proofSiblings, proofPathIndices);
-    }
-
-    /// @dev See {IInterep-getOffchainRoot}.
-    function getOffchainRoot(uint256 groupId) public view override returns (uint256) {
-        return offchainGroups[groupId].root;
-    }
-
-    /// @dev See {IInterep-getOffchainDepth}.
-    function getOffchainDepth(uint256 groupId) public view override returns (uint8) {
-        return offchainGroups[groupId].depth;
-    }
-
-    /// @dev Updates an offchain group.
+    /// @dev Updates an Interep group.
     /// @param groupId: Id of the group.
-    /// @param group: Offchain data.
-    function _updateOffchainGroup(uint256 groupId, OffchainGroup calldata group)
-        private
-        onlySupportedDepth(group.depth)
-    {
-        require(getDepth(groupId) == 0, "Interep: group id already exists onchain");
+    /// @param group: Group data.
+    function _updateGroup(uint256 groupId, Group calldata group) private onlySupportedDepth(group.depth) {
+        groups[groupId] = group;
 
-        offchainGroups[groupId] = group;
-
-        emit OffchainGroupUpdated(groupId, group.provider, group.name, group.root, group.depth);
+        emit GroupUpdated(groupId, group.provider, group.name, group.root, group.depth);
     }
 }

--- a/tasks/deploy-interep.ts
+++ b/tasks/deploy-interep.ts
@@ -1,4 +1,3 @@
-import { poseidon_gencontract as poseidonContract } from "circomlibjs"
 import { Contract } from "ethers"
 import { task, types } from "hardhat/config"
 
@@ -6,34 +5,7 @@ task("deploy:interep", "Deploy an Interep contract")
     .addOptionalParam<boolean>("logs", "Print the logs", true, types.boolean)
     .addParam("verifiers", "Tree depths and verifier addresses", undefined, types.json)
     .setAction(async ({ logs, verifiers }, { ethers }): Promise<Contract> => {
-        const poseidonABI = poseidonContract.generateABI(2)
-        const poseidonBytecode = poseidonContract.createCode(2)
-
-        const [signer] = await ethers.getSigners()
-
-        const PoseidonLibFactory = new ethers.ContractFactory(poseidonABI, poseidonBytecode, signer)
-        const poseidonLib = await PoseidonLibFactory.deploy()
-
-        await poseidonLib.deployed()
-
-        logs && console.log(`Poseidon library has been deployed to: ${poseidonLib.address}`)
-
-        const IncrementalBinaryTreeLibFactory = await ethers.getContractFactory("IncrementalBinaryTree", {
-            libraries: {
-                PoseidonT3: poseidonLib.address
-            }
-        })
-        const incrementalBinaryTreeLib = await IncrementalBinaryTreeLibFactory.deploy()
-
-        await incrementalBinaryTreeLib.deployed()
-
-        logs && console.log(`IncrementalBinaryTree library has been deployed to: ${incrementalBinaryTreeLib.address}`)
-
-        const ContractFactory = await ethers.getContractFactory("Interep", {
-            libraries: {
-                IncrementalBinaryTree: incrementalBinaryTreeLib.address
-            }
-        })
+        const ContractFactory = await ethers.getContractFactory("Interep")
 
         const contract = await ContractFactory.deploy(
             verifiers.map((v: [number, number]) => v[0]),

--- a/test/Interep.ts
+++ b/test/Interep.ts
@@ -1,185 +1,79 @@
 import { Strategy, ZkIdentity } from "@zk-kit/identity"
-import { generateMerkleProof, Semaphore, SemaphoreFullProof, SemaphoreSolidityProof } from "@zk-kit/protocols"
+import { Semaphore, SemaphoreFullProof, SemaphoreSolidityProof } from "@zk-kit/protocols"
 import { expect } from "chai"
 import { config as dotenvConfig } from "dotenv"
-import { constants, Signer, utils } from "ethers"
+import { utils } from "ethers"
 import { run } from "hardhat"
 import { resolve } from "path"
 import { Interep } from "../build/typechain/Interep"
-import { createIdentityCommitments, createOffchainGroupId, createTree } from "./utils"
+import { createGroupId, createIdentityCommitments, createTree } from "./utils"
 
 dotenvConfig({ path: resolve(__dirname, "../.env") })
 
 describe("Interep", () => {
     let contract: Interep
-    let signers: Signer[]
-    let accounts: string[]
 
     const groupProvider = utils.formatBytes32String("provider")
     const groupName = utils.formatBytes32String("name")
-    const offchainGroupId = createOffchainGroupId(groupProvider, groupName)
-    const groupId = 1
+    const groupId = createGroupId(groupProvider, groupName)
+    const tree = createTree(20)
     const members = createIdentityCommitments(3)
-    const depth = 20
 
     const wasmFilePath = "./static/semaphore.wasm"
     const finalZkeyPath = "./static/semaphore_final.zkey"
 
+    for (const member of members) {
+        tree.insert(member)
+    }
+
     before(async () => {
         const { address: verifierAddress } = await run("deploy:verifier", { logs: false })
-        contract = await run("deploy:interep", { logs: false, verifiers: [[depth, verifierAddress]] })
-
-        signers = await run("accounts", { logs: false })
-        accounts = await Promise.all(signers.map((signer: Signer) => signer.getAddress()))
+        contract = await run("deploy:interep", { logs: false, verifiers: [[tree.depth, verifierAddress]] })
     })
 
-    describe("# updateOffchainGroups", () => {
-        it("Should not publish new offchain groups if there is an unsupported tree depth", async () => {
-            const transaction = contract.updateOffchainGroups([
+    describe("# updateGroups", () => {
+        it("Should not publish new Interep groups if there is an unsupported tree depth", async () => {
+            const transaction = contract.updateGroups([
                 { provider: groupProvider, name: groupName, root: 1, depth: 10 }
             ])
 
             await expect(transaction).to.be.revertedWith("Interep: tree depth is not supported")
         })
 
-        it("Should not publish an offchain group if an onchain group with the same id already exists", async () => {
-            const groupProvider = utils.formatBytes32String("provider2")
-            const groupName = utils.formatBytes32String("name2")
-            const offchainGroupId = createOffchainGroupId(groupProvider, groupName)
-
-            await contract.createGroup(offchainGroupId, depth, accounts[0])
-
-            const transaction = contract.updateOffchainGroups([
-                { provider: groupProvider, name: groupName, root: 1, depth }
-            ])
-
-            await expect(transaction).to.be.revertedWith("Interep: group id already exists onchain")
-        })
-
-        it("Should publish 20 new offchain roots", async () => {
-            const offchainGroups: { provider: string; name: string; root: number; depth: number }[] = []
+        it("Should publish 20 new Interep groups", async () => {
+            const groups: { provider: string; name: string; root: number; depth: number }[] = []
 
             for (let i = 0; i < 20; i++) {
-                offchainGroups.push({
+                groups.push({
                     provider: groupProvider,
                     name: groupName,
-                    root: i,
-                    depth
+                    root: tree.root,
+                    depth: tree.depth
                 })
             }
 
-            const transaction = contract.updateOffchainGroups(offchainGroups)
+            const transaction = contract.updateGroups(groups)
 
             await expect(transaction)
-                .to.emit(contract, "OffchainGroupUpdated")
-                .withArgs(
-                    offchainGroupId,
-                    offchainGroups[0].provider,
-                    offchainGroups[0].name,
-                    offchainGroups[0].root,
-                    offchainGroups[0].depth
-                )
+                .to.emit(contract, "GroupUpdated")
+                .withArgs(groupId, groups[0].provider, groups[0].name, groups[0].root, groups[0].depth)
             expect((await (await transaction).wait()).events).to.length(20)
         })
     })
 
-    describe("# getOffchainRoot", () => {
-        it("Should get the tree root of an offchain group", async () => {
-            const root = await contract.getOffchainRoot(offchainGroupId)
+    describe("# getRoot", () => {
+        it("Should get the tree root of an Interep group", async () => {
+            const root = await contract.getRoot(groupId)
 
-            expect(root).to.equal(19)
+            expect(root).to.equal("10984560832658664796615188769057321951156990771630419931317114687214058410144")
         })
     })
 
     describe("# getOffchainDepth", () => {
-        it("Should get the tree depth of an offchain group", async () => {
-            const root = await contract.getOffchainDepth(offchainGroupId)
+        it("Should get the tree depth of an Interep group", async () => {
+            const root = await contract.getDepth(groupId)
 
-            expect(root).to.equal(depth)
-        })
-    })
-
-    describe("# createGroup", () => {
-        it("Should not create a group if the tree depth is not supported", async () => {
-            const transaction = contract.createGroup(groupId, 10, accounts[0])
-
-            await expect(transaction).to.be.revertedWith("Interep: tree depth is not supported")
-        })
-
-        it("Should create a group", async () => {
-            const transaction = contract.connect(signers[1]).createGroup(groupId, depth, accounts[1])
-
-            await expect(transaction).to.emit(contract, "GroupCreated").withArgs(groupId, depth, 0)
-            await expect(transaction)
-                .to.emit(contract, "GroupAdminUpdated")
-                .withArgs(groupId, constants.AddressZero, accounts[1])
-        })
-    })
-
-    describe("# updateGroupAdmin", () => {
-        it("Should not update a group admin if the caller is not the group admin", async () => {
-            const transaction = contract.updateGroupAdmin(groupId, accounts[0])
-
-            await expect(transaction).to.be.revertedWith("Interep: caller is not the group admin")
-        })
-
-        it("Should update the group admin", async () => {
-            const transaction = contract.connect(signers[1]).updateGroupAdmin(groupId, accounts[0])
-
-            await expect(transaction).to.emit(contract, "GroupAdminUpdated").withArgs(groupId, accounts[1], accounts[0])
-        })
-    })
-
-    describe("# addMember", () => {
-        it("Should not add a member if the caller is not the group admin", async () => {
-            const member = BigInt(2)
-
-            const transaction = contract.connect(signers[1]).addMember(groupId, member)
-
-            await expect(transaction).to.be.revertedWith("Interep: caller is not the group admin")
-        })
-
-        it("Should add a new member in an existing group", async () => {
-            const transaction = contract.addMember(groupId, members[0])
-
-            await expect(transaction)
-                .to.emit(contract, "MemberAdded")
-                .withArgs(
-                    groupId,
-                    members[0],
-                    "18951329906296061785889394467312334959162736293275411745101070722914184798221"
-                )
-        })
-    })
-
-    describe("# removeMember", () => {
-        it("Should not remove a member if the caller is not the group admin", async () => {
-            const transaction = contract.connect(signers[1]).removeMember(groupId, members[0], [0, 1], [0, 1])
-
-            await expect(transaction).to.be.revertedWith("Interep: caller is not the group admin")
-        })
-
-        it("Should remove a member from an existing group", async () => {
-            const groupId = 100
-            const tree = createTree(depth, 3)
-
-            tree.delete(0)
-
-            await contract.createGroup(groupId, depth, accounts[0])
-            await contract.addMember(groupId, BigInt(1))
-            await contract.addMember(groupId, BigInt(2))
-            await contract.addMember(groupId, BigInt(3))
-
-            const { siblings, pathIndices, root } = tree.createProof(0)
-
-            const transaction = contract.removeMember(
-                groupId,
-                BigInt(1),
-                siblings.map((s) => s[0]),
-                pathIndices
-            )
-
-            await expect(transaction).to.emit(contract, "MemberRemoved").withArgs(groupId, BigInt(1), root)
+            expect(root).to.equal(tree.depth)
         })
     })
 
@@ -187,8 +81,7 @@ describe("Interep", () => {
         const signal = "Hello world"
         const bytes32Signal = utils.formatBytes32String(signal)
         const identity = new ZkIdentity(Strategy.MESSAGE, "0")
-        const identityCommitment = identity.genIdentityCommitment()
-        const merkleProof = generateMerkleProof(depth, BigInt(0), members, identityCommitment)
+        const merkleProof = tree.createProof(0)
         const witness = Semaphore.genWitness(
             identity.getTrapdoor(),
             identity.getNullifier(),
@@ -201,9 +94,6 @@ describe("Interep", () => {
         let solidityProof: SemaphoreSolidityProof
 
         before(async () => {
-            await contract.addMember(groupId, members[1])
-            await contract.addMember(groupId, members[2])
-
             fullProof = await Semaphore.genProof(witness, wasmFilePath, finalZkeyPath)
             solidityProof = Semaphore.packToSolidityProof(fullProof.proof)
         })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -7,7 +7,7 @@ export const SNARK_SCALAR_FIELD = BigInt(
     "21888242871839275222246405745257275088548364400416034343698204186575808495617"
 )
 
-export function createOffchainGroupId(provider: string, name: string): bigint {
+export function createGroupId(provider: string, name: string): bigint {
     return BigInt(utils.solidityKeccak256(["bytes32", "bytes32"], [provider, name])) % SNARK_SCALAR_FIELD
 }
 


### PR DESCRIPTION
On-chain groups will be separately managed by Semaphore from now on. Interep will only focus on groups to export reputation from Web2 to Web3.